### PR TITLE
Vendor sqlite-sync implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dist
 .yarn/install-state.gz
 .pnp.*
 build
+
+# Local agent state
+.pi/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Workflow constraints
+- Do not push directly to `main`. Make changes on a branch and send them through a pull request.
+- If you change public API, runtime behavior, or examples, update `README.md` in the same change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
       "dependencies": {
         "@databases/connection-pool": "^1.1.0",
         "@databases/escape-identifier": "^1.0.3",
+        "@databases/split-sql-query": "^1.0.4",
         "@databases/sql": "^3.3.0",
-        "@databases/sqlite-sync": "^3.0.0"
+        "@types/better-sqlite3": "^7.6.13",
+        "better-sqlite3": "^12.10.0"
       },
       "devDependencies": {
         "@types/node": "^25.2.3",
@@ -55,28 +57,16 @@
       "resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.3.0.tgz",
       "integrity": "sha512-vj9huEy4mjJ48GS1Z8yvtMm4BYAnFYACUds25ym6Gd/gsnngkJ17fo62a6mmbNNwCBS/8467PmZR01Zs/06TjA=="
     },
-    "node_modules/@databases/sqlite-sync": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@databases/sqlite-sync/-/sqlite-sync-3.0.0.tgz",
-      "integrity": "sha512-E/vzK7fH8P5aWk54DR/zEA6IHx65b4R5fWgGPDaBH39QcJvZm89C6q9tl+6E3t3kbCTdzhohZdFNbOEbV1s2WQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@databases/escape-identifier": "^1.0.3",
-        "@databases/split-sql-query": "^1.0.4",
-        "@databases/sql": "^3.3.0",
-        "@types/better-sqlite3": "^7.6.9",
-        "better-sqlite3": "^11.3.0"
-      }
-    },
     "node_modules/@databases/validate-unicode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@databases/validate-unicode/-/validate-unicode-1.0.0.tgz",
       "integrity": "sha512-dLKqxGcymeVwEb/6c44KjOnzaAafFf0Wxa8xcfEjx/qOl3rdijsKYBAtIGhtVtOlpPf/PFKfgTuFurSPn/3B/g=="
     },
     "node_modules/@types/better-sqlite3": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.10.tgz",
-      "integrity": "sha512-TZBjD+yOsyrUJGmcUj6OS3JADk3+UZcNv3NOBqGkM09bZdi28fNZw8ODqbMOLfKCu7RYCO62/ldq1iHbzxqoPw==",
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -111,14 +101,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.7.0.tgz",
-      "integrity": "sha512-mXpa5jnIKKHeoGzBrUJrc65cXFKcILGZpU3FXR0pradUEm9MA7UZz02qfEejaMcm9iXrSOCenwwYMJ/tZ1y5Ig==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "dependencies": {
     "@databases/connection-pool": "^1.1.0",
     "@databases/escape-identifier": "^1.0.3",
+    "@databases/split-sql-query": "^1.0.4",
     "@databases/sql": "^3.3.0",
-    "@databases/sqlite-sync": "^3.0.0"
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.10.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,179 @@
-import sql, { SQLQuery, isSqlQuery } from "@databases/sql";
-import connect, {
-  DatabaseConnection as SyncDatabaseConnection,
-} from "@databases/sqlite-sync";
 import createBaseConnectionPool, {
   ConnectionPool,
   PoolConnection,
   PoolOptions,
 } from "@databases/connection-pool";
 import { escapeSQLiteIdentifier } from "@databases/escape-identifier";
+import sql, { SQLQuery, isSqlQuery } from "@databases/sql";
+import splitSqlQuery from "@databases/split-sql-query";
 import { once } from "events";
+import DatabaseConstructor = require("better-sqlite3");
 
 export type { SQLQuery };
 export { sql, isSqlQuery };
 
-type connectParameters = Parameters<typeof connect>;
+type DatabaseOptions = DatabaseConstructor.Options;
+type BetterSqlite3Database = DatabaseConstructor.Database;
 
-type DatabaseOptions = connectParameters[1];
+const IN_MEMORY = ":memory:";
+
+// Synchronous adapter vendored from @databases/sqlite-sync@3.0.0.
+// Copyright (c) 2019 Forbes Lindesay, MIT License.
+const sqliteFormat = {
+  escapeIdentifier: (str: string) => escapeSQLiteIdentifier(str),
+  formatValue: (value: unknown) => ({ placeholder: "?", value }),
+};
+
+interface SyncDatabaseTransaction {
+  query(query: SQLQuery): any[];
+  query(query: SQLQuery[]): any[][];
+  queryStream(query: SQLQuery): IterableIterator<any>;
+}
+
+interface SyncDatabaseConnection extends SyncDatabaseTransaction {
+  tx<T>(fn: (db: SyncDatabaseTransaction) => T): T;
+  dispose(): void;
+}
+
+class SyncDatabaseTransactionImplementation implements SyncDatabaseTransaction {
+  #database: BetterSqlite3Database;
+
+  constructor(database: BetterSqlite3Database) {
+    this.#database = database;
+  }
+
+  query(query: SQLQuery): any[];
+  query(query: SQLQuery[]): any[][];
+  query(query: SQLQuery | SQLQuery[]): any[] | any[][] {
+    return runQuery(query, this.#database);
+  }
+
+  queryStream(query: SQLQuery): IterableIterator<any> {
+    return runQueryStream(query, this.#database);
+  }
+}
+
+class SyncDatabaseConnectionImplementation implements SyncDatabaseConnection {
+  #database: BetterSqlite3Database;
+  #begin: DatabaseConstructor.Statement;
+  #commit: DatabaseConstructor.Statement;
+  #rollback: DatabaseConstructor.Statement;
+
+  constructor(filename: string, options: DatabaseOptions) {
+    this.#database = new DatabaseConstructor(filename, options);
+    this.#begin = this.#database.prepare("BEGIN");
+    this.#commit = this.#database.prepare("COMMIT");
+    this.#rollback = this.#database.prepare("ROLLBACK");
+  }
+
+  query(query: SQLQuery): any[];
+  query(query: SQLQuery[]): any[][];
+  query(query: SQLQuery | SQLQuery[]): any[] | any[][] {
+    return runQuery(query, this.#database);
+  }
+
+  queryStream(query: SQLQuery): IterableIterator<any> {
+    return runQueryStream(query, this.#database);
+  }
+
+  tx<T>(fn: (db: SyncDatabaseTransaction) => T): T {
+    this.#begin.run();
+    try {
+      const result = fn(
+        new SyncDatabaseTransactionImplementation(this.#database),
+      );
+      this.#commit.run();
+      return result;
+    } catch (ex) {
+      this.#rollback.run();
+      throw ex;
+    }
+  }
+
+  dispose(): void {
+    this.#database.close();
+  }
+}
+
+function connect(
+  filename: string = IN_MEMORY,
+  options: DatabaseOptions = {},
+): SyncDatabaseConnection {
+  return new SyncDatabaseConnectionImplementation(filename, options);
+}
+
+function runQuery(query: SQLQuery, database: BetterSqlite3Database): any[];
+function runQuery(query: SQLQuery[], database: BetterSqlite3Database): any[][];
+function runQuery(
+  query: SQLQuery | SQLQuery[],
+  database: BetterSqlite3Database,
+): any[] | any[][];
+function runQuery(
+  query: SQLQuery | SQLQuery[],
+  database: BetterSqlite3Database,
+): any[] | any[][] {
+  if (Array.isArray(query)) {
+    for (const q of query) {
+      if (!isSqlQuery(q)) {
+        throw new Error(
+          "Invalid query, you must use @databases/sql to create your queries.",
+        );
+      }
+    }
+    return query.map((q) => runOneQuery(q, database));
+  }
+
+  if (!isSqlQuery(query)) {
+    throw new Error(
+      "Invalid query, you must use @databases/sql to create your queries.",
+    );
+  }
+
+  const queries = splitSqlQuery(query);
+  const lastQuery = queries.pop();
+  if (!lastQuery) {
+    return [];
+  }
+
+  for (const q of queries) {
+    runOneQuery(q, database);
+  }
+  return runOneQuery(lastQuery, database);
+}
+
+function runOneQuery(query: SQLQuery, database: BetterSqlite3Database): any[] {
+  const { text, values } = query.format(sqliteFormat);
+  const statement = database.prepare(text);
+  try {
+    return statement.all(...values);
+  } catch (_err) {
+    const err = _err as Error;
+    // TODO we should be able to catch this before calling all()
+    if (err.message.indexOf("This statement does not return data") >= 0) {
+      statement.run(...values);
+      return [];
+    }
+    throw err;
+  }
+}
+
+function* runQueryStream(
+  query: SQLQuery,
+  database: BetterSqlite3Database,
+): IterableIterator<any> {
+  if (!isSqlQuery(query)) {
+    throw new Error(
+      "Invalid query, you must use @databases/sql to create your queries.",
+    );
+  }
+
+  const { text, values } = query.format(sqliteFormat);
+  const statement = database.prepare(text);
+  const rows = statement.iterate(...values);
+  for (const row of rows || []) {
+    yield row;
+  }
+}
 
 export interface DatabaseTransaction {
   query(query: SQLQuery): Promise<any[]>;


### PR DESCRIPTION
## Summary
- vendor the synchronous sqlite adapter from @databases/sqlite-sync into src/index.ts
- remove @databases/sqlite-sync and depend directly on better-sqlite3 12.10.0
- add Node 24 and 26 to the CI matrix
- ignore local .pi agent state

## Validation
- npx tsc --noEmit
- npm run lint
- npm test
